### PR TITLE
feat: Create shared library for LBCircularBuffer

### DIFF
--- a/src/shared/LBCircularBuffer/APITester/APITester.lpi
+++ b/src/shared/LBCircularBuffer/APITester/APITester.lpi
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="/"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="APITester"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <Units>
+      <Unit>
+        <Filename Value="APITester.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="/"/>
+    <Target>
+      <Filename Value="APITester"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Linking>
+      <Options>
+        <Win32>
+          <GraphicApplication Value="False"/>
+        </Win32>
+      </Options>
+    </Linking>
+    <Other>
+      <CompilerMessages>
+        <MsgFileName Value=""/>
+      </CompilerMessages>
+      <CompilerPath Value="$(CompPath)"/>
+    </Other>
+  </CompilerOptions>
+</CONFIG>

--- a/src/shared/LBCircularBuffer/APITester/APITester.lpr
+++ b/src/shared/LBCircularBuffer/APITester/APITester.lpr
@@ -1,0 +1,161 @@
+program APITester;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, SysUtils, DynLibs;
+
+type
+  // Define function pointer types matching the exported C-API
+  TLBCB_Create = function(aSize: Cardinal): Pointer; cdecl;
+  TLBCB_Destroy = procedure(aHandle: Pointer); cdecl;
+  TLBCB_Write = function(aHandle: Pointer; aData: PByte; aCount: Cardinal): Boolean; cdecl;
+  TLBCB_Read = function(aHandle: Pointer; aData: PByte; aCount: Cardinal): Boolean; cdecl;
+  TLBCB_GetAvailableForRead = function(aHandle: Pointer): Cardinal; cdecl;
+  TLBCB_GetAvailableForWrite = function(aHandle: Pointer): Cardinal; cdecl;
+  TLBCB_Clear = procedure(aHandle: Pointer); cdecl;
+  TLBCB_Initialize = procedure(aLogFileName: PChar; aLogLevel: Integer); cdecl;
+  TLBCB_Finalize = procedure(); cdecl;
+
+var
+  // Variables to hold the function pointers
+  LBCB_Create: TLBCB_Create;
+  LBCB_Destroy: TLBCB_Destroy;
+  LBCB_Write: TLBCB_Write;
+  LBCB_Read: TLBCB_Read;
+  LBCB_GetAvailableForRead: TLBCB_GetAvailableForRead;
+  LBCB_GetAvailableForWrite: TLBCB_GetAvailableForWrite;
+  LBCB_Clear: TLBCB_Clear;
+  LBCB_Initialize: TLBCB_Initialize;
+  LBCB_Finalize: TLBCB_Finalize;
+
+procedure WriteLnSuccess(aMessage: String);
+begin
+  WriteLn('[ OK ] ', aMessage);
+end;
+
+procedure WriteLnFail(aMessage: String);
+begin
+  WriteLn('[FAIL] ', aMessage);
+  Halt(1);
+end;
+
+procedure Check(aCondition: Boolean; aSuccessMsg: String; aFailMsg: String);
+begin
+  if aCondition then
+    WriteLnSuccess(aSuccessMsg)
+  else
+    WriteLnFail(aFailMsg);
+end;
+
+procedure RunTests;
+var
+  BufferHandle: Pointer;
+  DataIn, DataOut: array[0..15] of Byte;
+  i: Integer;
+begin
+  WriteLn('--- Running LBCircularBuffer API Tests ---');
+
+  // 1. Create Test
+  BufferHandle := LBCB_Create(64);
+  Check(BufferHandle <> nil, 'LBCB_Create: Buffer created successfully.', 'LBCB_Create: Failed to create buffer.');
+
+  // 2. Write Test
+  for i := 0 to 15 do DataIn[i] := i;
+  Check(LBCB_Write(BufferHandle, @DataIn[0], Length(DataIn)),
+    'LBCB_Write: Wrote 16 bytes.', 'LBCB_Write: Failed to write data.');
+
+  // 3. AvailableForRead Test
+  Check(LBCB_GetAvailableForRead(BufferHandle) = 16,
+    'LBCB_GetAvailableForRead: Correct count (16).',
+    'LBCB_GetAvailableForRead: Incorrect count. Expected 16, got ' + IntToStr(LBCB_GetAvailableForRead(BufferHandle)));
+
+  // 4. Read Test
+  Check(LBCB_Read(BufferHandle, @DataOut[0], Length(DataOut)),
+    'LBCB_Read: Read 16 bytes.', 'LBCB_Read: Failed to read data.');
+
+  // 5. Data Integrity Test
+  for i := 0 to 15 do
+  begin
+    if DataIn[i] <> DataOut[i] then
+      WriteLnFail('Data Integrity: Mismatch at index ' + IntToStr(i));
+  end;
+  WriteLnSuccess('Data Integrity: All bytes match.');
+
+  // 6. Final Count Test
+  Check(LBCB_GetAvailableForRead(BufferHandle) = 0,
+    'LBCB_GetAvailableForRead: Correct final count (0).',
+    'LBCB_GetAvailableForRead: Incorrect final count. Expected 0.');
+
+  // 7. Clear Test
+  LBCB_Write(BufferHandle, @DataIn[0], 8);
+  Check(LBCB_GetAvailableForRead(BufferHandle) = 8, 'LBCB_Write: Wrote 8 bytes for clear test.', 'LBCB_Write: Failed clear test write.');
+  LBCB_Clear(BufferHandle);
+  Check(LBCB_GetAvailableForRead(BufferHandle) = 0, 'LBCB_Clear: Buffer cleared successfully.', 'LBCB_Clear: Buffer not empty after clear.');
+
+  // 8. Destroy Test
+  LBCB_Destroy(BufferHandle);
+  WriteLnSuccess('LBCB_Destroy: Buffer destroyed.');
+
+  WriteLn('--- All Tests Passed ---');
+end;
+
+var
+  LibHandle: TLibHandle;
+  LibName: String;
+begin
+  {$IFDEF UNIX}
+  LibName := './libLBCircularBuffer_shared.so';
+  {$ENDIF}
+  {$IFDEF WINDOWS}
+  LibName := 'LBCircularBuffer_shared.dll';
+  {$ENDIF}
+
+  WriteLn('Loading library: ' + LibName);
+  LibHandle := LoadLibrary(LibName);
+
+  if LibHandle = NilHandle then
+  begin
+    WriteLn('FATAL: Could not load shared library: ' + LibName);
+    Halt(1);
+  end;
+
+  try
+    // Get function addresses
+    @LBCB_Create := GetProcedureAddress(LibHandle, 'LBCB_Create');
+    @LBCB_Destroy := GetProcedureAddress(LibHandle, 'LBCB_Destroy');
+    @LBCB_Write := GetProcedureAddress(LibHandle, 'LBCB_Write');
+    @LBCB_Read := GetProcedureAddress(LibHandle, 'LBCB_Read');
+    @LBCB_GetAvailableForRead := GetProcedureAddress(LibHandle, 'LBCB_GetAvailableForRead');
+    @LBCB_GetAvailableForWrite := GetProcedureAddress(LibHandle, 'LBCB_GetAvailableForWrite');
+    @LBCB_Clear := GetProcedureAddress(LibHandle, 'LBCB_Clear');
+    @LBCB_Initialize := GetProcedureAddress(LibHandle, 'LBCB_Initialize');
+    @LBCB_Finalize := GetProcedureAddress(LibHandle, 'LBCB_Finalize');
+
+    if (@LBCB_Create = nil) or (@LBCB_Destroy = nil) or (@LBCB_Write = nil) or (@LBCB_Initialize = nil) or (@LBCB_Finalize = nil) then
+    begin
+      WriteLn('FATAL: Could not find all required functions in the library.');
+      Halt(1);
+    end;
+
+    WriteLn('Library loaded and all functions found.');
+
+    // Initialize Logger
+    LBCB_Initialize('APITester.log', 5);
+    WriteLnSuccess('Logger Initialized via API call.');
+
+    // Run the tests
+    RunTests;
+
+  finally
+    // Finalize Logger
+    if @LBCB_Finalize <> nil then
+    begin
+      LBCB_Finalize;
+      WriteLnSuccess('Logger Finalized via API call.');
+    end;
+
+    WriteLn('Unloading library.');
+    UnloadLibrary(LibHandle);
+  end;
+end.

--- a/src/shared/LBCircularBuffer/LBCircularBuffer_shared.lpi
+++ b/src/shared/LBCircularBuffer/LBCircularBuffer_shared.lpi
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="/"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="LBCircularBuffer_shared"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages>
+      <Item>
+        <PackageName Value="LCL"/>
+      </Item>
+    </RequiredPackages>
+    <Units>
+      <Unit>
+        <Filename Value="LBCircularBuffer_shared.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="lbcbuffer_capi.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="/"/>
+    <Target>
+      <Filename Value="../../lib/LBCircularBuffer_shared"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+      <SrcPath Value="../../utils"/>
+    </SearchPaths>
+    <Parsing>
+      <SyntaxOptions>
+        <SyntaxMode Value="objfpc"/>
+      </SyntaxOptions>
+    </Parsing>
+    <CodeGeneration>
+      <SmartLinkUnit Value="True"/>
+    </CodeGeneration>
+    <Linking>
+      <Options>
+        <Win32>
+          <GraphicApplication Value="True"/>
+        </Win32>
+      </Options>
+    </Linking>
+    <Other>
+      <CompilerMessages>
+        <MsgFileName Value=""/>
+      </CompilerMessages>
+      <CompilerPath Value="$(CompPath)"/>
+    </Other>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions>
+      <Item>
+        <Name Value="EAbort"/>
+      </Item>
+      <Item>
+        <Name Value="ECodetoolError"/>
+      </Item>
+      <Item>
+        <Name Value="EFOpenError"/>
+      </Item>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/src/shared/LBCircularBuffer/LBCircularBuffer_shared.lpr
+++ b/src/shared/LBCircularBuffer/LBCircularBuffer_shared.lpr
@@ -1,0 +1,20 @@
+library LBCircularBuffer_shared;
+
+{$mode objfpc}{$H+}
+
+uses
+  lbcbuffer_capi in 'lbcbuffer_capi.pas';
+
+exports
+  LBCB_Initialize,
+  LBCB_Finalize,
+  LBCB_Create,
+  LBCB_Destroy,
+  LBCB_Write,
+  LBCB_Read,
+  LBCB_GetAvailableForRead,
+  LBCB_GetAvailableForWrite,
+  LBCB_Clear;
+
+begin
+end.

--- a/src/shared/LBCircularBuffer/lbcbuffer_capi.pas
+++ b/src/shared/LBCircularBuffer/lbcbuffer_capi.pas
@@ -1,0 +1,98 @@
+unit lbcbuffer_capi;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, uLBCircularBuffer, ULBLogger;
+
+procedure LBCB_Initialize(aLogFileName: PChar; aLogLevel: Integer); export; cdecl;
+procedure LBCB_Finalize; export; cdecl;
+function LBCB_Create(aSize: Cardinal): Pointer; export; cdecl;
+procedure LBCB_Destroy(aHandle: Pointer); export; cdecl;
+function LBCB_Write(aHandle: Pointer; aData: PByte; aCount: Cardinal): Boolean; export; cdecl;
+function LBCB_Read(aHandle: Pointer; aData: PByte; aCount: Cardinal): Boolean; export; cdecl;
+function LBCB_GetAvailableForRead(aHandle: Pointer): Cardinal; export; cdecl;
+function LBCB_GetAvailableForWrite(aHandle: Pointer): Cardinal; export; cdecl;
+procedure LBCB_Clear(aHandle: Pointer); export; cdecl;
+
+implementation
+
+procedure LBCB_Initialize(aLogFileName: PChar; aLogLevel: Integer);
+var
+  LogFileName: string;
+begin
+  LogFileName := StrPas(aLogFileName);
+  if (LogFileName <> '') and (aLogLevel > 0) then
+  begin
+    InitLogger(aLogLevel, LogFileName, False, False);
+  end;
+end;
+
+procedure LBCB_Finalize;
+begin
+  ReleaseLogger;
+end;
+
+function LBCB_Create(aSize: Cardinal): Pointer;
+var
+  Buffer: TLBCircularBufferThreaded;
+begin
+  Result := nil;
+  try
+    Buffer := TLBCircularBufferThreaded.Create(aSize);
+    Result := Pointer(Buffer);
+  except
+    on E: Exception do
+      // In a real library, you might want to log this or handle it differently
+      Result := nil;
+  end;
+end;
+
+procedure LBCB_Destroy(aHandle: Pointer);
+begin
+  if aHandle <> nil then
+    TLBCircularBufferThreaded(aHandle).Free;
+end;
+
+function LBCB_Write(aHandle: Pointer; aData: PByte; aCount: Cardinal): Boolean;
+begin
+  Result := False;
+  if aHandle <> nil then
+    Result := TLBCircularBufferThreaded(aHandle).Write(aData, aCount);
+end;
+
+function LBCB_Read(aHandle: Pointer; aData: PByte; aCount: Cardinal): Boolean;
+begin
+  Result := False;
+  if aHandle <> nil then
+    Result := TLBCircularBufferThreaded(aHandle).Read(aData, aCount);
+end;
+
+function LBCB_GetAvailableForRead(aHandle: Pointer): Cardinal;
+begin
+  Result := 0;
+  if aHandle <> nil then
+    Result := TLBCircularBufferThreaded(aHandle).Buffer.AvailableForRead;
+end;
+
+function LBCB_GetAvailableForWrite(aHandle: Pointer): Cardinal;
+begin
+  Result := 0;
+  if aHandle <> nil then
+    Result := TLBCircularBufferThreaded(aHandle).Buffer.AvailableForWrite;
+end;
+
+procedure LBCB_Clear(aHandle: Pointer);
+begin
+  if aHandle <> nil then
+    TLBCircularBufferThreaded(aHandle).BufferCS.Acquire('LBCB_Clear');
+    try
+      TLBCircularBufferThreaded(aHandle).Buffer.Clear;
+    finally
+      TLBCircularBufferThreaded(aHandle).BufferCS.Release;
+    end;
+end;
+
+end.


### PR DESCRIPTION
Creates a shared library (.dll/.so) for the LBCircularBuffer component to allow its use from other programming languages.

- Adds a new Lazarus library project in `src/shared/LBCircularBuffer/`.
- Implements a C-style API wrapper (`lbcbuffer_capi.pas`) that exports functions for creating, destroying, and operating on the circular buffer.
- The C-API uses the thread-safe `TLBCircularBufferThreaded` internally.
- Adds `LBCB_Initialize` and `LBCB_Finalize` functions to manage a self-contained logger for the library.
- Includes a console-based test application (`APITester`) that dynamically loads the shared library and verifies its functionality.