### PR TITLE
I've created a shared library for your LBLogger component, now with c…

### DIFF
--- a/src/shared/LBLogger/APITester/APITester.lpi
+++ b/src/shared/LBLogger/APITester/APITester.lpi
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="/"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="APITester"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <Units>
+      <Unit>
+        <Filename Value="APITester.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="/"/>
+    <Target>
+      <Filename Value="APITester"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+    </SearchPaths>
+    <Linking>
+      <Options>
+        <Win32>
+          <GraphicApplication Value="False"/>
+        </Win32>
+      </Options>
+    </Linking>
+    <Other>
+      <CompilerMessages>
+        <MsgFileName Value=""/>
+      </CompilerMessages>
+      <CompilerPath Value="$(CompPath)"/>
+    </Other>
+  </CompilerOptions>
+</CONFIG>

--- a/src/shared/LBLogger/APITester/APITester.lpr
+++ b/src/shared/LBLogger/APITester/APITester.lpr
@@ -1,0 +1,145 @@
+program APITester;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, SysUtils, DynLibs;
+
+// C-API function pointer types
+type
+  TLogCallback = procedure(aLevel: Integer; aSender: PChar; aMessage: PChar); cdecl;
+
+  TLBLog_Initialize = procedure(aLogFileName: PChar; aLogLevel: Integer); cdecl;
+  TLBLog_Finalize = procedure(); cdecl;
+  TLBLog_Write = procedure(aLevel: Integer; aSender: PChar; aMessage: PChar); cdecl;
+  TLBLog_CreateCallbackSublogger = function(aCallback: TLogCallback): Pointer; cdecl;
+  TLBLog_DestroySublogger = procedure(aHandle: Pointer); cdecl;
+
+var
+  // Function pointer variables
+  LBLog_Initialize: TLBLog_Initialize;
+  LBLog_Finalize: TLBLog_Finalize;
+  LBLog_Write: TLBLog_Write;
+  LBLog_CreateCallbackSublogger: TLBLog_CreateCallbackSublogger;
+  LBLog_DestroySublogger: TLBLog_DestroySublogger;
+
+  // Global variable to check if our callback was called
+  G_CallbackWasCalled: Boolean = False;
+  G_CallbackMessage: String = '';
+
+// This is the callback function that we will pass to the logger library.
+procedure MyLogCallback(aLevel: Integer; aSender: PChar; aMessage: PChar); cdecl;
+begin
+  WriteLn('[CALLBACK CALLED] Level: ', aLevel, ', Sender: ', StrPas(aSender), ', Message: ', StrPas(aMessage));
+  G_CallbackWasCalled := True;
+  G_CallbackMessage := StrPas(aMessage);
+end;
+
+procedure WriteLnSuccess(aMessage: String);
+begin
+  WriteLn('[ OK ] ', aMessage);
+end;
+
+procedure WriteLnFail(aMessage: String);
+begin
+  WriteLn('[FAIL] ', aMessage);
+  Halt(1);
+end;
+
+procedure Check(aCondition: Boolean; aSuccessMsg: String; aFailMsg: String);
+begin
+  if aCondition then
+    WriteLnSuccess(aSuccessMsg)
+  else
+    WriteLnFail(aFailMsg);
+end;
+
+procedure RunTests;
+var
+  CallbackLoggerHandle: Pointer;
+  TestMessage: String;
+begin
+  WriteLn('--- Running LBLogger API Tests ---');
+
+  // 1. Create Callback Sublogger
+  CallbackLoggerHandle := LBLog_CreateCallbackSublogger(@MyLogCallback);
+  Check(CallbackLoggerHandle <> nil, 'CreateCallbackSublogger: Sublogger created.', 'CreateCallbackSublogger: Failed to create sublogger.');
+
+  // 2. Test the callback
+  TestMessage := 'This is a test message for the callback.';
+  G_CallbackWasCalled := False; // Reset flag
+  LBLog_Write(1, 'APITester', PChar(TestMessage));
+
+  Check(G_CallbackWasCalled, 'LBLog_Write: Callback was invoked.', 'LBLog_Write: Callback was NOT invoked.');
+  Check(G_CallbackMessage = TestMessage, 'Callback Message: Message content is correct.', 'Callback Message: Message content is incorrect.');
+
+  // 3. Test writing to file log
+  // (This assumes the main logger writes to file, which we can't check here, but we call the function)
+  LBLog_Write(1, 'APITester', 'This should go to the file log.');
+  WriteLnSuccess('LBLog_Write: Message sent to file logger.');
+
+  // 4. Destroy Sublogger
+  LBLog_DestroySublogger(CallbackLoggerHandle);
+  WriteLnSuccess('DestroySublogger: Callback sublogger destroyed.');
+
+  // 5. Verify callback is no longer called
+  G_CallbackWasCalled := False; // Reset flag
+  LBLog_Write(1, 'APITester', 'This message should NOT trigger the callback.');
+  Check(not G_CallbackWasCalled, 'Post-Destroy: Callback was not invoked, as expected.', 'Post-Destroy: Callback was invoked after being destroyed.');
+
+  WriteLn('--- All Tests Passed ---');
+end;
+
+var
+  LibHandle: TLibHandle;
+  LibName: String;
+begin
+  {$IFDEF UNIX}
+  LibName := './libLBLogger_shared.so';
+  {$ENDIF}
+  {$IFDEF WINDOWS}
+  LibName := 'LBLogger_shared.dll';
+  {$ENDIF}
+
+  WriteLn('Loading library: ' + LibName);
+  LibHandle := LoadLibrary(LibName);
+
+  if LibHandle = NilHandle then
+  begin
+    WriteLn('FATAL: Could not load shared library: ' + LibName);
+    Halt(1);
+  end;
+
+  try
+    // Get function addresses from the library
+    @LBLog_Initialize := GetProcedureAddress(LibHandle, 'LBLog_Initialize');
+    @LBLog_Finalize := GetProcedureAddress(LibHandle, 'LBLog_Finalize');
+    @LBLog_Write := GetProcedureAddress(LibHandle, 'LBLog_Write');
+    @LBLog_CreateCallbackSublogger := GetProcedureAddress(LibHandle, 'LBLog_CreateCallbackSublogger');
+    @LBLog_DestroySublogger := GetProcedureAddress(LibHandle, 'LBLog_DestroySublogger');
+
+    if (@LBLog_Initialize = nil) or (@LBLog_Finalize = nil) or (@LBLog_Write = nil) or
+       (@LBLog_CreateCallbackSublogger = nil) or (@LBLog_DestroySublogger = nil) then
+    begin
+      WriteLn('FATAL: Could not find all required functions in the library.');
+      Halt(1);
+    end;
+
+    WriteLn('Library loaded and all functions found.');
+
+    // Initialize the main logger to write to a file
+    LBLog_Initialize('APITester_main.log', 5);
+    WriteLnSuccess('Main logger initialized via API call.');
+
+    // Run the tests
+    RunTests;
+
+  finally
+    // Finalize the main logger
+    if @LBLog_Finalize <> nil then
+      LBLog_Finalize;
+
+    WriteLn('Unloading library.');
+    UnloadLibrary(LibHandle);
+  end;
+end.

--- a/src/shared/LBLogger/LBLogger_shared.lpi
+++ b/src/shared/LBLogger/LBLogger_shared.lpi
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <PathDelim Value="/"/>
+    <General>
+      <Flags>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <Title Value="LBLogger_shared"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <BuildModes>
+      <Item Name="Default" Default="True"/>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+      <UseFileFilters Value="True"/>
+    </PublishOptions>
+    <RunParams>
+      <FormatVersion Value="2"/>
+    </RunParams>
+    <RequiredPackages>
+      <Item>
+        <PackageName Value="LCL"/>
+      </Item>
+    </RequiredPackages>
+    <Units>
+      <Unit>
+        <Filename Value="LBLogger_shared.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="lblogger_capi.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <PathDelim Value="/"/>
+    <Target>
+      <Filename Value="../../lib/LBLogger_shared"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir)"/>
+      <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
+      <SrcPath Value="../../utils;../../LBLogger"/>
+    </SearchPaths>
+    <Parsing>
+      <SyntaxOptions>
+        <SyntaxMode Value="objfpc"/>
+      </SyntaxOptions>
+    </Parsing>
+    <CodeGeneration>
+      <SmartLinkUnit Value="True"/>
+    </CodeGeneration>
+    <Linking>
+      <Options>
+        <Win32>
+          <GraphicApplication Value="True"/>
+        </Win32>
+      </Options>
+    </Linking>
+    <Other>
+      <CompilerMessages>
+        <MsgFileName Value=""/>
+      </CompilerMessages>
+      <CompilerPath Value="$(CompPath)"/>
+    </Other>
+  </CompilerOptions>
+</CONFIG>

--- a/src/shared/LBLogger/LBLogger_shared.lpr
+++ b/src/shared/LBLogger/LBLogger_shared.lpr
@@ -1,0 +1,16 @@
+library LBLogger_shared;
+
+{$mode objfpc}{$H+}
+
+uses
+  lblogger_capi in 'lblogger_capi.pas';
+
+exports
+  LBLog_Initialize,
+  LBLog_Finalize,
+  LBLog_Write,
+  LBLog_CreateCallbackSublogger,
+  LBLog_DestroySublogger;
+
+begin
+end.

--- a/src/shared/LBLogger/lblogger_capi.pas
+++ b/src/shared/LBLogger/lblogger_capi.pas
@@ -1,0 +1,75 @@
+unit lblogger_capi;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, ULBLogger, uCallbackLogger;
+
+procedure LBLog_Initialize(aLogFileName: PChar; aLogLevel: Integer); export; cdecl;
+procedure LBLog_Finalize; export; cdecl;
+procedure LBLog_Write(aLevel: Integer; aSender: PChar; aMessage: PChar); export; cdecl;
+function LBLog_CreateCallbackSublogger(aCallback: TLogCallback): Pointer; export; cdecl;
+procedure LBLog_DestroySublogger(aHandle: Pointer); export; cdecl;
+
+implementation
+
+procedure LBLog_Initialize(aLogFileName: PChar; aLogLevel: Integer);
+var
+  LogFileName: string;
+begin
+  if LBLogger <> nil then Exit; // Already initialized
+
+  LogFileName := StrPas(aLogFileName);
+  InitLogger(aLogLevel, LogFileName, False, False);
+end;
+
+procedure LBLog_Finalize;
+begin
+  ReleaseLogger;
+end;
+
+procedure LBLog_Write(aLevel: Integer; aSender: PChar; aMessage: PChar);
+begin
+  if LBLogger <> nil then
+    LBLogger.Write(aLevel, StrPas(aSender), lmt_Info, StrPas(aMessage));
+end;
+
+function LBLog_CreateCallbackSublogger(aCallback: TLogCallback): Pointer;
+var
+  CallbackLogger: TCallbackLogger;
+begin
+  Result := nil;
+  if (LBLogger = nil) or (not Assigned(aCallback)) then Exit;
+
+  try
+    CallbackLogger := TCallbackLogger.Create(aCallback);
+    if LBLogger.addAlternativeLogger(CallbackLogger) then
+      Result := Pointer(CallbackLogger)
+    else
+      CallbackLogger.Free;
+  except
+    on E: Exception do
+      // In case of error, ensure we don't leak memory
+      Result := nil;
+  end;
+end;
+
+procedure LBLog_DestroySublogger(aHandle: Pointer);
+var
+  Sublogger: TObject;
+begin
+  if (LBLogger = nil) or (aHandle = nil) then Exit;
+
+  Sublogger := TObject(aHandle);
+  if Sublogger is TCallbackLogger then
+  begin
+    // removeAlternativeLogger will also free the object if it was the owner,
+    // but we free it explicitly to be safe. The list is non-owning.
+    LBLogger.removeAlternativeLogger(TCallbackLogger(Sublogger));
+    Sublogger.Free;
+  end;
+end;
+
+end.

--- a/src/shared/LBLogger/uCallbackLogger.pas
+++ b/src/shared/LBLogger/uCallbackLogger.pas
@@ -1,0 +1,53 @@
+unit uCallbackLogger;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, ULBLogger;
+
+type
+  // Define the C-style callback function pointer type
+  TLogCallback = procedure(aLevel: Integer; aSender: PChar; aMessage: PChar); cdecl;
+
+  { TCallbackLogger }
+  // A sublogger that forwards log messages to a C-style callback function.
+  TCallbackLogger = class(TLBBaseLogger)
+  strict private
+    FCallback: TLogCallback;
+  protected
+    function virtualWrite(LogLevel: Byte; const Sender: String; MsgType: TLBLoggerMessageType; var MsgText: String): Boolean; override;
+  public
+    constructor Create(aCallback: TLogCallback); reintroduce;
+  end;
+
+implementation
+
+{ TCallbackLogger }
+
+constructor TCallbackLogger.Create(aCallback: TLogCallback);
+begin
+  // Call inherited Create, but pass False for AppendToMainLogger
+  // because we will add it manually after creation.
+  inherited Create('CallbackLogger', False);
+  FCallback := aCallback;
+end;
+
+function TCallbackLogger.virtualWrite(LogLevel: Byte; const Sender: String; MsgType: TLBLoggerMessageType; var MsgText: String): Boolean;
+begin
+  Result := False;
+  if not Assigned(FCallback) then Exit;
+  if not (MsgType in Self.EnabledMessages) then Exit;
+  if LogLevel > Self.MaxLogLevel then Exit;
+
+  try
+    FCallback(LogLevel, PChar(Sender), PChar(MsgText));
+    Result := True;
+  except
+    // If the callback fails, we can't do much, but we shouldn't crash the logger.
+    // A potential improvement could be to log this failure to the main file logger.
+  end;
+end;
+
+end.


### PR DESCRIPTION
This makes the component accessible from other programming languages.

The key feature of this implementation is a C-API that supports custom subloggers via function pointer callbacks. This approach preserves the extensibility of the original design in a language-agnostic way.

Here's a summary of the changes I made:
- Added a new Lazarus library project in `src/shared/LBLogger/`.
- Implemented a `TCallbackLogger` class that inherits from `TLBBaseLogger` and invokes a C-style function pointer.
- Implemented a C-API wrapper (`lblogger_capi.pas`) with functions to initialize the logger, write messages, and manage callback-based subloggers (`LBLog_CreateCallbackSublogger`, `LBLog_DestroySublogger`).
- Included a console-based test application (`APITester`) that dynamically loads the library to verify that the callback mechanism is working correctly.