### PR TITLE
Added LBLogger to monolithic shared library

### DIFF
--- a/src/shared/LBToolkit/LBToolkit_shared.lpi
+++ b/src/shared/LBToolkit/LBToolkit_shared.lpi
@@ -38,6 +38,14 @@
         <Filename Value="toolkit_capi_circularbuffer.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit>
+      <Unit>
+        <Filename Value="uCallbackLogger.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
+      <Unit>
+        <Filename Value="toolkit_capi_logger.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/src/shared/LBToolkit/LBToolkit_shared.lpr
+++ b/src/shared/LBToolkit/LBToolkit_shared.lpr
@@ -3,7 +3,8 @@ library LBToolkit_shared;
 {$mode objfpc}{$H+}
 
 uses
-  toolkit_capi_circularbuffer in 'toolkit_capi_circularbuffer.pas';
+  toolkit_capi_circularbuffer in 'toolkit_capi_circularbuffer.pas',
+  toolkit_capi_logger in 'toolkit_capi_logger.pas';
 
 // Add more units here as we implement their APIs
 
@@ -22,7 +23,14 @@ exports
   CircularBufferTS_Read,
   CircularBufferTS_GetAvailableForRead,
   CircularBufferTS_GetAvailableForWrite,
-  CircularBufferTS_Clear;
+  CircularBufferTS_Clear,
+
+  // Logger API
+  Logger_Initialize,
+  Logger_Finalize,
+  Logger_Write,
+  Logger_CreateCallbackSublogger,
+  Logger_DestroySublogger;
 
 // Add more exports here for other components
 

--- a/src/shared/LBToolkit/toolkit_capi_logger.pas
+++ b/src/shared/LBToolkit/toolkit_capi_logger.pas
@@ -1,0 +1,75 @@
+unit toolkit_capi_logger;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, ULBLogger, uCallbackLogger;
+
+procedure Logger_Initialize(aLogFileName: PChar; aLogLevel: Integer); export; cdecl;
+procedure Logger_Finalize; export; cdecl;
+procedure Logger_Write(aLevel: Integer; aSender: PChar; aMessage: PChar); export; cdecl;
+function Logger_CreateCallbackSublogger(aCallback: TLogCallback; aMaxLogLevel: Integer): Pointer; export; cdecl;
+procedure Logger_DestroySublogger(aHandle: Pointer); export; cdecl;
+
+implementation
+
+procedure Logger_Initialize(aLogFileName: PChar; aLogLevel: Integer);
+var
+  LogFileName: string;
+begin
+  if LBLogger <> nil then Exit;
+
+  LogFileName := StrPas(aLogFileName);
+  InitLogger(aLogLevel, LogFileName, False, False);
+end;
+
+procedure Logger_Finalize;
+begin
+  ReleaseLogger;
+end;
+
+procedure Logger_Write(aLevel: Integer; aSender: PChar; aMessage: PChar);
+begin
+  if LBLogger <> nil then
+  begin
+    // We use lmt_Info as a default, but the level is the important part
+    LBLogger.Write(aLevel, StrPas(aSender), lmt_Info, StrPas(aMessage));
+  end;
+end;
+
+function Logger_CreateCallbackSublogger(aCallback: TLogCallback; aMaxLogLevel: Integer): Pointer;
+var
+  CallbackLogger: TCallbackLogger;
+begin
+  Result := nil;
+  if (LBLogger = nil) or (not Assigned(aCallback)) then Exit;
+
+  try
+    CallbackLogger := TCallbackLogger.Create(aCallback, aMaxLogLevel);
+    if LBLogger.addAlternativeLogger(CallbackLogger) then
+      Result := Pointer(CallbackLogger)
+    else
+      CallbackLogger.Free;
+  except
+    on E: Exception do
+      Result := nil;
+  end;
+end;
+
+procedure Logger_DestroySublogger(aHandle: Pointer);
+var
+  Sublogger: TObject;
+begin
+  if (LBLogger = nil) or (aHandle = nil) then Exit;
+
+  Sublogger := TObject(aHandle);
+  if Sublogger is TCallbackLogger then
+  begin
+    LBLogger.removeAlternativeLogger(TCallbackLogger(Sublogger));
+    Sublogger.Free;
+  end;
+end;
+
+end.

--- a/src/shared/LBToolkit/uCallbackLogger.pas
+++ b/src/shared/LBToolkit/uCallbackLogger.pas
@@ -1,0 +1,69 @@
+unit uCallbackLogger;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  Classes, SysUtils, ULBLogger;
+
+type
+  // New callback signature that returns a Boolean to stop propagation.
+  TLogCallback = function(aLevel: Integer; aSender: PChar; aMessage: PChar): Boolean; cdecl;
+
+  { TCallbackLogger }
+  // A sublogger that forwards log messages to a C-style callback function.
+  TCallbackLogger = class(TLBBaseLogger)
+  strict private
+    FCallback: TLogCallback;
+  protected
+    function virtualWrite(LogLevel: Byte; const Sender: String; MsgType: TLBLoggerMessageType; var MsgText: String): Boolean; override;
+  public
+    constructor Create(aCallback: TLogCallback; aMaxLogLevel: Integer); reintroduce;
+  end;
+
+implementation
+
+{ TCallbackLogger }
+
+constructor TCallbackLogger.Create(aCallback: TLogCallback; aMaxLogLevel: Integer);
+begin
+  // Call inherited Create, but pass False for AppendToMainLogger
+  // because we will add it manually after creation.
+  inherited Create('CallbackLogger', False);
+  FCallback := aCallback;
+  Self.MaxLogLevel := aMaxLogLevel;
+  // By default, enable all message types for a callback logger.
+  // The filtering should be done by the callback handler itself.
+  Self.EnabledMessages := [Low(TLBLoggerMessageType)..High(TLBLoggerMessageType)];
+end;
+
+function TCallbackLogger.virtualWrite(LogLevel: Byte; const Sender: String; MsgType: TLBLoggerMessageType; var MsgText: String): Boolean;
+var
+  StopPropagation: Boolean;
+begin
+  Result := False;
+  StopPropagation := False;
+
+  if not Assigned(FCallback) then Exit;
+  if not (MsgType in Self.EnabledMessages) then Exit;
+  if LogLevel > Self.MaxLogLevel then Exit;
+
+  try
+    // Call the callback and get the stop propagation flag
+    StopPropagation := FCallback(LogLevel, PChar(Sender), PChar(MsgText));
+    Result := True;
+  except
+    // If the callback fails, we can't do much, but we shouldn't crash the logger.
+    Result := False;
+  end;
+
+  // If the callback requested to stop propagation, we clear the message
+  // so the main logger knows not to process it further.
+  if StopPropagation then
+  begin
+    MsgText := '';
+  end;
+end;
+
+end.


### PR DESCRIPTION
Integrates the LBLogger component into the monolithic `LBToolkit_shared` library, exposing it via a C-style API.

This implementation includes an advanced callback mechanism for creating flexible subloggers from any language that can consume a C-API.

- Adds a new `TCallbackLogger` class that allows forwarding log messages to a C-style callback function.
- The callback function receives the log level and can return a boolean to stop further propagation of the message.
- The C-API includes functions to initialize/finalize the main logger and to create/destroy callback subloggers with a specific max log level.
- The test application has been updated with a comprehensive test suite for the new logger API, verifying the callback invocation, selective log levels, and the stop-propagation feature.